### PR TITLE
Use module machine name as key in hook_requirements().

### DIFF
--- a/islandora_cwrc_basexdb.install
+++ b/islandora_cwrc_basexdb.install
@@ -13,15 +13,14 @@ function islandora_cwrc_basexdb_requirements($phase) {
   $requirements = array(
     'islandora_cwrc_basexdb' => array('title' => $t('CWRC BaseX XML Database')),
   );
-  $library = array(
-    'library path' => libraries_get_path('basex-api'),
-  );
-  if (file_exists($library['library path'])) {
+  $library = libraries_detect('basex-api');
+  if ($library['installed']) {
     $requirements['islandora_cwrc_basexdb']['severity'] = REQUIREMENT_OK;
+    $requirements['islandora_cwrc_basexdb']['value'] = $library['version'];
   }
   else {
     $requirements['islandora_cwrc_basexdb']['severity'] = REQUIREMENT_ERROR;
-    $requirements['islandora_cwrc_basexdb']['value'] = $t('Not found');
+    $requirements['islandora_cwrc_basexdb']['value'] = $library['error'];
     $requirements['islandora_cwrc_basexdb']['description'] = $t('The <a href="@url">BaseX PHP client Library</a> is missing. <a href="@download">Download @library-file</a> and extract it into the <code>@directory</code> directory. Add the folder <code>@library-folder</code> and add @library-file.', array(
         '@cwrc' => 'https://github.com/BaseXdb/basex',
         '@download' => 'https://github.com/BaseXdb/basex/blob/master/basex-api/src/main/php/BaseXClient.php',

--- a/islandora_cwrc_basexdb.install
+++ b/islandora_cwrc_basexdb.install
@@ -11,18 +11,18 @@
 function islandora_cwrc_basexdb_requirements($phase) {
   $t = get_t();
   $requirements = array(
-    'cwrc' => array('title' => $t('CWRC BaseX XML Database')),
+    'islandora_cwrc_basexdb' => array('title' => $t('CWRC BaseX XML Database')),
   );
   $library = array(
     'library path' => libraries_get_path('basex-api'),
   );
   if (file_exists($library['library path'])) {
-    $requirements['cwrc']['severity'] = REQUIREMENT_OK;
+    $requirements['islandora_cwrc_basexdb']['severity'] = REQUIREMENT_OK;
   }
   else {
-    $requirements['cwrc']['severity'] = REQUIREMENT_ERROR;
-    $requirements['cwrc']['value'] = $t('Not found');
-    $requirements['cwrc']['description'] = $t('The <a href="@url">BaseX PHP client Library</a> is missing. <a href="@download">Download @library-file</a> and extract it into the <code>@directory</code> directory. Add the folder <code>@library-folder</code> and add @library-file.', array(
+    $requirements['islandora_cwrc_basexdb']['severity'] = REQUIREMENT_ERROR;
+    $requirements['islandora_cwrc_basexdb']['value'] = $t('Not found');
+    $requirements['islandora_cwrc_basexdb']['description'] = $t('The <a href="@url">BaseX PHP client Library</a> is missing. <a href="@download">Download @library-file</a> and extract it into the <code>@directory</code> directory. Add the folder <code>@library-folder</code> and add @library-file.', array(
         '@cwrc' => 'https://github.com/BaseXdb/basex',
         '@download' => 'https://github.com/BaseXdb/basex/blob/master/basex-api/src/main/php/BaseXClient.php',
         '@directory' => 'sites/all/libraries',

--- a/islandora_cwrc_basexdb.module
+++ b/islandora_cwrc_basexdb.module
@@ -63,5 +63,26 @@ function islandora_cwrc_basexdb_permission() {
   );
 }
 
+/**
+ * Implements hook_libraries_info().
+ */
+function islandora_cwrc_basexdb_libraries_info() {
+  $libraries = array();
 
+  // Support for BaseX, the XML Database.
+  $libraries['basex-api'] = array(
+    'name' => 'CWRC BaseX XML Database',
+    'vendor url' => 'https://github.com/BaseXdb/basex',
+    'download url' => 'https://github.com/BaseXdb/basex/blob/master/basex-api/src/main/php/BaseXClient.php',
+    'download file url' => 'https://raw.githubusercontent.com/BaseXdb/basex/master/basex-api/src/main/php/BaseXClient.php',
+    'version arguments' => array(
+      'file' => 'BaseXClient.php',
+      'pattern' => '@Works with BaseX ([0-9a-zA-Z\.-]+) and later@',
+    ),
+    'files' => array(
+      'php' => array('BaseXClient.php'),
+    ),
+  );
 
+  return $libraries;
+}


### PR DESCRIPTION
# Problem / motivation

> As a site administrator, I want separate status report items for `islandora_cwrc_basexdb` and `islandora_cwrc_writer` so that I can tell whether each module is working independently of the other.
> As a site administrator, I don't want to see unnecessary "Array to string conversion errors" when I go to the status report page or in my log messages, so that I can spend less time administrating the site and important messages do not get lost in the noise.

Previously, in `hook_requirements()`, this module prefixed all of its status information under the key `cwrc`, which conflicted with the `islandora_cwrc_writer` module (see discoverygarden/islandora_cwrc_writer#75 for a change to that module), and also caused "Array to string conversion" errors on the site's status report as two unrelated status lines were mashed together.

# Proposed resolution

Prefix all of this module's status information under a key with the same machine name as the module.

# Remaining tasks

- [ ] Code review
- [ ] Commit

# User interface changes

The status report lines for `islandora_cwrc_basexdb` and `islandora_cwrc_writer` are now separate.

# API changes

Anything wishing to override the status report item for this module must now override the requirement with key `islandora_cwrc_basexdb`.

# Data model changes

None.